### PR TITLE
FLA-1566 Critical Vulnerabilies. Bumped Java -> 17, Sprint -> 3

### DIFF
--- a/.github/workflows/maven-test.yaml
+++ b/.github/workflows/maven-test.yaml
@@ -9,10 +9,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
-    - name: Set up JDK 1.8
+    - name: Set up JDK 17
       uses: actions/setup-java@v1
       with:
-        java-version: 1.8
+        java-version: 17
     - uses: actions/cache@v1
       with:
         path: ~/.m2/repository

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-java@v1
         with:
-          java-version: 1.8
+          java-version: 17
       - uses: actions/cache@v1
         with:
           path: ~/.m2/repository

--- a/src/bambora-payment-starter/pom.xml
+++ b/src/bambora-payment-starter/pom.xml
@@ -5,11 +5,11 @@
 
 	<groupId>ca.bc.gov.open</groupId>
 	<artifactId>bambora-payment-starter</artifactId>
-	<version>0.2.2</version>
+	<version>1.0.0</version>
 
 	<properties>
-		<java.version>1.8</java.version>
-		<spring-boot.version>2.2.4.RELEASE</spring-boot.version>
+		<java.version>17</java.version>
+		<spring-boot.version>3.1.3</spring-boot.version>
 		<log4j2.version>2.17.1</log4j2.version>
 	</properties>
 
@@ -69,7 +69,7 @@
 			<dependency>
 				<groupId>ca.bc.gov.open</groupId>
 				<artifactId>spring-starters-bom</artifactId>
-				<version>0.2.2</version>
+				<version>1.0.0</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>

--- a/src/bambora-payment-starter/src/main/java/ca/bc/gov/open/bambora/payment/starter/managment/BamboraCardService.java
+++ b/src/bambora-payment-starter/src/main/java/ca/bc/gov/open/bambora/payment/starter/managment/BamboraCardService.java
@@ -1,9 +1,11 @@
 package ca.bc.gov.open.bambora.payment.starter.managment;
 
+import java.net.URI;
+
 import ca.bc.gov.open.bambora.payment.starter.managment.models.RecurringPaymentDetails;
-import com.sun.jndi.toolkit.url.Uri;
 
 public interface BamboraCardService {
-    Uri setupRecurringPayment(RecurringPaymentDetails recurringPaymentDetails);
+	
+	URI setupRecurringPayment(RecurringPaymentDetails recurringPaymentDetails);
 
 }

--- a/src/bambora-payment-starter/src/main/java/ca/bc/gov/open/bambora/payment/starter/managment/BamboraCardServiceImpl.java
+++ b/src/bambora-payment-starter/src/main/java/ca/bc/gov/open/bambora/payment/starter/managment/BamboraCardServiceImpl.java
@@ -1,17 +1,19 @@
 package ca.bc.gov.open.bambora.payment.starter.managment;
 
-import ca.bc.gov.open.bambora.payment.starter.BamboraConstants;
-import ca.bc.gov.open.bambora.payment.starter.BamboraException;
-import ca.bc.gov.open.bambora.payment.starter.BamboraProperties;
-import ca.bc.gov.open.bambora.payment.starter.managment.models.RecurringPaymentDetails;
-import com.sun.jndi.toolkit.url.Uri;
-import org.apache.commons.codec.digest.DigestUtils;
-
 import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.text.MessageFormat;
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.Date;
+
+import org.apache.commons.codec.digest.DigestUtils;
+
+import ca.bc.gov.open.bambora.payment.starter.BamboraConstants;
+import ca.bc.gov.open.bambora.payment.starter.BamboraException;
+import ca.bc.gov.open.bambora.payment.starter.BamboraProperties;
+import ca.bc.gov.open.bambora.payment.starter.managment.models.RecurringPaymentDetails;
 
 public class BamboraCardServiceImpl implements BamboraCardService {
 
@@ -22,16 +24,18 @@ public class BamboraCardServiceImpl implements BamboraCardService {
     }
 
     @Override
-    public Uri setupRecurringPayment(RecurringPaymentDetails recurringPaymentDetails) {
+    public URI setupRecurringPayment(RecurringPaymentDetails recurringPaymentDetails) {
         try {
             return buildRecurringPaymentUrl(recurringPaymentDetails);
         } catch (MalformedURLException e) {
             throw new BamboraException("Url construction failed", e.getCause());
-        }
+        } catch (URISyntaxException e) {
+            throw new BamboraException("Url construction failed", e.getCause());
+		}
     }
 
 
-    private Uri buildRecurringPaymentUrl(RecurringPaymentDetails recurringPaymentDetails) throws MalformedURLException {
+    private URI buildRecurringPaymentUrl(RecurringPaymentDetails recurringPaymentDetails) throws MalformedURLException, URISyntaxException {
 
         String operationType = (recurringPaymentDetails.getEndUserId() != null ? BamboraConstants.OperationTypes.M.toString() : BamboraConstants.OperationTypes.N.toString());
 
@@ -56,7 +60,7 @@ public class BamboraCardServiceImpl implements BamboraCardService {
 
         paramString.append(MessageFormat.format("&{0}={1}&{2}={3}",  BamboraConstants.PARAM_TRANS_HASH_VALUE, getHash(paramString.toString()), BamboraConstants.PARAM_TRANS_HASH_EXPIRY, getExpiry()));
 
-        return new Uri(MessageFormat.format("{0}?{1}", bamboraProperties.getHostedProfileUrl(), paramString.toString()));
+        return new URI(MessageFormat.format("{0}?{1}", bamboraProperties.getHostedProfileUrl(), paramString.toString()));
 
     }
 

--- a/src/bambora-payment-starter/src/test/java/ca/bc/gov/open/bambora/payment/starter/managment/BamboraCardServiceImplTest.java
+++ b/src/bambora-payment-starter/src/test/java/ca/bc/gov/open/bambora/payment/starter/managment/BamboraCardServiceImplTest.java
@@ -1,10 +1,16 @@
 package ca.bc.gov.open.bambora.payment.starter.managment;
 
+import java.net.URI;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
 import ca.bc.gov.open.bambora.payment.starter.BamboraException;
 import ca.bc.gov.open.bambora.payment.starter.BamboraProperties;
 import ca.bc.gov.open.bambora.payment.starter.managment.models.RecurringPaymentDetails;
-import com.sun.jndi.toolkit.url.Uri;
-import org.junit.jupiter.api.*;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @DisplayName("Test BamboraCardServiceImpl")
@@ -42,7 +48,7 @@ public class BamboraCardServiceImplTest {
     public void withClientIdCreateUpdateUrl() {
         sut = new BamboraCardServiceImpl(bamboraProperties);
 
-        Uri actual = sut.setupRecurringPayment(createPaymentDetail(END_USER_ID));
+        URI actual = sut.setupRecurringPayment(createPaymentDetail(END_USER_ID));
 
         Assertions.assertNotNull(actual);
         Assertions.assertTrue(actual.toString().contains(BAMBORA_CLIENT_URL));
@@ -54,7 +60,7 @@ public class BamboraCardServiceImplTest {
     public void withoutClientIdCreateUpdateUrl() {
         sut = new BamboraCardServiceImpl(bamboraProperties);
 
-        Uri actual = sut.setupRecurringPayment(createPaymentDetail(null));
+        URI actual = sut.setupRecurringPayment(createPaymentDetail(null));
 
         Assertions.assertNotNull(actual);
         Assertions.assertTrue(actual.toString().contains(BAMBORA_NEW_URL));

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -5,14 +5,14 @@
 
     <groupId>ca.bc.gov.open</groupId>
     <artifactId>spring-starters</artifactId>
-    <version>0.2.2</version>
+    <version>1.0.0</version>
 
     <name>spring-starters</name>
     <packaging>pom</packaging>
     <url>https://github.com/bcgov/spring-boot-starters</url>
 
     <properties>
-        <java.version>1.8</java.version>
+        <java.version>17</java.version>
         <log4j2.version>2.17.1</log4j2.version>
     </properties>
 

--- a/src/spring-bceid-starter/pom.xml
+++ b/src/spring-bceid-starter/pom.xml
@@ -6,16 +6,20 @@
 
     <groupId>ca.bc.gov.open</groupId>
     <artifactId>spring-bceid-starter</artifactId>
-    <version>0.2.2</version>
+    <version>1.0.0</version>
 
     <properties>
-        <java.version>1.8</java.version>
+        <java.version>17</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
-        <spring-boot.version>2.2.4.RELEASE</spring-boot.version>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+        <spring-boot.version>3.1.3</spring-boot.version>
         <org.mapstruct.version>1.3.1.Final</org.mapstruct.version>
         <log4j2.version>2.17.1</log4j2.version>
+        <org.apache.cxf.version>4.0.1</org.apache.cxf.version>
+        
+        <!-- automatically run annotation processors within the incremental compilation (Eclipse) -->
+  		<m2e.apt.activation>jdt_apt</m2e.apt.activation>
     </properties>
 
     <distributionManagement>
@@ -95,7 +99,7 @@
             <dependency>
                 <groupId>ca.bc.gov.open</groupId>
                 <artifactId>spring-starters-bom</artifactId>
-                <version>0.2.2</version>
+                <version>1.0.0</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -126,7 +130,7 @@
             <plugin>
                 <groupId>org.apache.cxf</groupId>
                 <artifactId>cxf-codegen-plugin</artifactId>
-                <version>3.3.7</version>
+                <version>${org.apache.cxf.version}</version>
                 <executions>
                     <execution>
                         <id>generate-sources</id>

--- a/src/spring-clamav-starter/pom.xml
+++ b/src/spring-clamav-starter/pom.xml
@@ -6,14 +6,14 @@
 
     <groupId>ca.bc.gov.open</groupId>
     <artifactId>spring-clamav-starter</artifactId>
-    <version>0.2.2</version>
+    <version>1.0.0</version>
 
     <properties>
-        <java.version>1.8</java.version>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
-        <spring-boot.version>2.2.4.RELEASE</spring-boot.version>
-        <org.apache.maven.plugins.version.version>2.22.0</org.apache.maven.plugins.version.version>
+        <java.version>17</java.version>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+        <spring-boot.version>3.1.3</spring-boot.version>
+        <org.apache.maven.plugins.version.version>3.1.2</org.apache.maven.plugins.version.version>
         <log4j2.version>2.17.1</log4j2.version>
     </properties>
 
@@ -63,7 +63,7 @@
             <dependency>
                 <groupId>ca.bc.gov.open</groupId>
                 <artifactId>spring-starters-bom</artifactId>
-                <version>0.2.2</version>
+                <version>1.0.0</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -87,7 +87,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.2</version>
+                <version>0.8.7</version>
                 <executions>
                     <execution>
                         <goals>

--- a/src/spring-clamav-starter/src/test/java/ca/bc/gov/open/clamav/starter/ClamAvServiceImplTest.java
+++ b/src/spring-clamav-starter/src/test/java/ca/bc/gov/open/clamav/starter/ClamAvServiceImplTest.java
@@ -23,7 +23,7 @@ class ClamAvServiceImplTest {
     @BeforeEach
     void setUp() throws IOException {
 
-        MockitoAnnotations.initMocks(this);
+        MockitoAnnotations.openMocks(this);
         sut = new ClamAvServiceImpl(clamAvClient);
 
     }

--- a/src/spring-sftp-starter/pom.xml
+++ b/src/spring-sftp-starter/pom.xml
@@ -7,13 +7,13 @@
 
     <groupId>ca.bc.gov.open</groupId>
     <artifactId>spring-sftp-starter</artifactId>
-    <version>0.2.2</version>
+    <version>1.0.0</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
-        <spring-boot.version>2.2.4.RELEASE</spring-boot.version>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+        <spring-boot.version>3.1.3</spring-boot.version>
         <log4j2.version>2.17.1</log4j2.version>
     </properties>
 
@@ -79,7 +79,7 @@
             <dependency>
                 <groupId>ca.bc.gov.open</groupId>
                 <artifactId>spring-starters-bom</artifactId>
-                <version>0.2.2</version>
+                <version>1.0.0</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/src/spring-starters-bom/pom.xml
+++ b/src/spring-starters-bom/pom.xml
@@ -13,7 +13,7 @@
         <org.apache.cxf.version>4.0.1</org.apache.cxf.version>
         <com.fasterxml.jackson.core.version>2.11.2</com.fasterxml.jackson.core.version>
         <javax.xml.bind.version>2.3.1</javax.xml.bind.version>
-        <commons.io.version>1.4</commons.io.version>
+        <commons.io.version>2.13.0</commons.io.version>
         <joda-time.version>2.10.6</joda-time.version>
         <org.mapstruct.version>1.3.1.Final</org.mapstruct.version>
         <fi.solita.clamav>1.0.1</fi.solita.clamav>

--- a/src/spring-starters-bom/pom.xml
+++ b/src/spring-starters-bom/pom.xml
@@ -7,10 +7,10 @@
 
     <groupId>ca.bc.gov.open</groupId>
     <artifactId>spring-starters-bom</artifactId>
-    <version>0.2.2</version>
+    <version>1.0.0</version>
 
     <properties>
-        <org.apache.cxf.version>3.3.7</org.apache.cxf.version>
+        <org.apache.cxf.version>4.0.1</org.apache.cxf.version>
         <com.fasterxml.jackson.core.version>2.11.2</com.fasterxml.jackson.core.version>
         <javax.xml.bind.version>2.3.1</javax.xml.bind.version>
         <commons.io.version>1.4</commons.io.version>


### PR DESCRIPTION
FLA-1566 attempts to address a great many critical vulnerabilities with this project.
- bumped **Java** from 1.8 to **17**
- bumped **Spring Boot** from 2.2.4.RELEASE to **3.1.3**
- bumped **Apache CXF** from 3.3.7 to **4.0.1**
- Fixed use of java.net.URI
- Fixed use of Mockito
- Fixed m2e activation so mapstruct properly generates code in Eclipse.
- bumped .github **workflow** and **publish** builds to use Java **17**
- bumped commons.io to 2.13.0 

Since this is a major change, bumped **project version** from 0.2.2 to **1.0.0**.