### PR TITLE
FLA-1566 Updated autoconfiguration for Spring 3

### DIFF
--- a/src/bambora-payment-starter/src/main/resources/META-INF/spring.factories
+++ b/src/bambora-payment-starter/src/main/resources/META-INF/spring.factories
@@ -1,2 +1,0 @@
-org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-  ca.bc.gov.open.bambora.payment.starter.AutoConfiguration

--- a/src/bambora-payment-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/src/bambora-payment-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+ca.bc.gov.open.bambora.payment.starter.AutoConfiguration

--- a/src/spring-bceid-starter/src/main/resources/META-INF/spring.factories
+++ b/src/spring-bceid-starter/src/main/resources/META-INF/spring.factories
@@ -1,2 +1,0 @@
-org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-  ca.bc.gov.open.bceid.starter.AutoConfiguration

--- a/src/spring-bceid-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/src/spring-bceid-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+ca.bc.gov.open.bceid.starter.AutoConfiguration

--- a/src/spring-clamav-starter/src/main/resources/META-INF/spring.factories
+++ b/src/spring-clamav-starter/src/main/resources/META-INF/spring.factories
@@ -1,2 +1,0 @@
-org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-  ca.bc.gov.open.clamav.starter.AutoConfiguration

--- a/src/spring-clamav-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/src/spring-clamav-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+ca.bc.gov.open.clamav.starter.AutoConfiguration

--- a/src/spring-sftp-starter/src/main/resources/META-INF/spring.factories
+++ b/src/spring-sftp-starter/src/main/resources/META-INF/spring.factories
@@ -1,3 +1,0 @@
-org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-  ca.bc.gov.open.sftp.starter.AutoConfiguration
-  

--- a/src/spring-sftp-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/src/spring-sftp-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,2 @@
+ca.bc.gov.open.sftp.starter.AutoConfiguration
+  


### PR DESCRIPTION
Spring 3 changed the way autoconfiguration is initialised from Spring 2.

Renamed 
`/src/main/resources/META-INF/spring.factories`
to
`/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports`